### PR TITLE
add the ability to check a file to see if a user is debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,7 @@ To collect telegraf metrics you must define the hiera value `profile_gpu::dcgm::
 - This is set to no value in data/common.yaml and must be defined in your project control-repo.
 - See REFERENCE.md for details
 
-In order to enable Nvidia performance counters on Ampere and older cards (Hopper may not require this work around), DCGM must not be running and collecting data. Disabling DCGM and Telegraf can be done via a Slurm prolog/epilog (an example is listed below. To make this profile not restart the services, a fact has been created to look for a file. This file is defined in Hiera:
-
-- `profile_gpu::dcgm::telegraf::nv_debug_check: "/var/spool/slurmd/nvperfenabled"`
-
-If this file is found, DCGM and Telegraf will not be restarted.
+In order to enable Nvidia performance counters on Ampere and older cards (Hopper may not require this work around), DCGM must not be running and collecting data. Disabling DCGM and Telegraf can be done via a Slurm prolog/epilog (an example is listed below. To make this profile not restart the services, a fact has been created to look for a file. This file is hardcoded to look at '/var/spool/slurmd/nvperfenabled'. If this file is found, DCGM and Telegraf will not be restarted.
 
 Prolog:
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -14,3 +14,4 @@ profile_gpu::dcgm::install::dcgm_version: "2.4.6-1"  # 2.4.6-1 is known to work,
 profile_gpu::dcgm::telegraf::dcgm_telegraf_port: 8094
 profile_gpu::dcgm::telegraf::dcgm_telegraf_py_port: 5556
 profile_gpu::dcgm::telegraf::enable: true
+profile_gpu::dcgm::telegraf::nv_debug_check: "/var/spool/slurmd/nvperfenabled"

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -14,4 +14,3 @@ profile_gpu::dcgm::install::dcgm_version: "2.4.6-1"  # 2.4.6-1 is known to work,
 profile_gpu::dcgm::telegraf::dcgm_telegraf_port: 8094
 profile_gpu::dcgm::telegraf::dcgm_telegraf_py_port: 5556
 profile_gpu::dcgm::telegraf::enable: true
-profile_gpu::dcgm::telegraf::nv_debug_check: "/var/spool/slurmd/nvperfenabled"

--- a/lib/facter/debugging_check.rb
+++ b/lib/facter/debugging_check.rb
@@ -1,0 +1,9 @@
+Facter.add('nvdebugging') do
+  setcode do
+    if File.exist? '/var/spool/slurmd/nvperfenabled'
+       true
+    else
+       false
+    end
+  end
+end

--- a/manifests/dcgm/telegraf.pp
+++ b/manifests/dcgm/telegraf.pp
@@ -9,6 +9,12 @@
 # @param enable
 #   Enable or disable telegraf reporting for DCGM
 #
+# @param allownvdebugging
+#   Enable a file check to not reenable dcgm when a user is debugging
+#
+# @param nvidia_debug_check
+#   The file to check to see if user is debugging and not start the service
+#
 # @example
 #   include profile_gpu::dcgm::telegraf
 class profile_gpu::dcgm::telegraf (
@@ -22,108 +28,108 @@ class profile_gpu::dcgm::telegraf (
   } else {
     $ensure_parm = 'absent'
   }
-
-  #
+  
+ 
   # Setup nvidia-dcgm systemd service
   #
-  systemd::unit_file { 'nvidia-dcgm.service':
-    content => file("${module_name}/nvidia-dcgm.service"),
-    enable  => $enable,
-    active  => $enable,
-    before  => Systemd::Unit_File['dcgmd-telegraf.service'],
-    require => Package['datacenter-gpu-manager'],
+  if $facts['nvdebugging'] != true {
+    systemd::unit_file { 'nvidia-dcgm.service':
+      content => file("${module_name}/nvidia-dcgm.service"),
+      enable  => $enable,
+      before  => Systemd::Unit_File['dcgmd-telegraf.service'],
+      require => Package['datacenter-gpu-manager'],
+      active  => $enable,
+    }
+    #
+    # Setup dcgmd-telegraf
+    #
+
+    # Setup variables
+    if find_file('/usr/bin/python3') {
+      $exec_start = '/usr/bin/python3'
+      $dcgm_telegraf_py_path = '/usr/local/dcgm/bindings/python3/dcgm_telegraf.py'
+    } elsif find_file('/usr/bin/python') {
+      $exec_start = '/usr/bin/python'
+      $dcgm_telegraf_py_path = '/usr/local/dcgm/bindings/dcgm_telegraf.py'
+    } else {
+      fail('Unable to determine python version')
+    }
+
+    # TMP fix in place for some bug in NVIDIA DCGM
+    file_line { 'fix_dcgm_telegraf_py':
+      path               => $dcgm_telegraf_py_path,
+      match              => '        self\.m_sock.sendto\(payload, self\.m_dest\)',
+      line               => '        self.m_sock.sendto(payload.encode(), self.m_dest)',
+      append_on_no_match => 'false',
+      require            => Package['datacenter-gpu-manager'],
+      notify             => Service['dcgmd-telegraf.service'],
+    }
+
+    # First Modification so dcgmd-telegraf listens on a static port and only on localhost
+    file_line { 'dcgm_telegraf_py_localhost_listen_only':
+      path               => $dcgm_telegraf_py_path,
+      after              => '^DEFAULT_TELEGRAF_PORT = .*',
+      line               => "LISTEN_HOST = '127.0.0.1'",
+      append_on_no_match => 'false',
+      require            => Package['datacenter-gpu-manager'],
+      notify             => Service['dcgmd-telegraf.service'],
+    }
+
+    # Second Modification so dcgmd-telegraf listens on a static port and only on localhost
+    file_line { 'dcgm_telegraf_py_localhost_listen_only_part2':
+      path    => $dcgm_telegraf_py_path,
+      after   => "LISTEN_HOST = '127.0.0.1'",
+      match   => '^LISTEN_PORT = .*',
+      line    => "LISTEN_PORT = ${dcgm_telegraf_py_port}",
+      require => [ Package['datacenter-gpu-manager'], File_Line['dcgm_telegraf_py_localhost_listen_only'] ],
+      notify  => Service['dcgmd-telegraf.service'],
+    }
+
+    # Third Modification so dcgmd-telegraf listens on a static port and only on localhost
+    file_line { 'dcgm_telegraf_py_localhost_listen_only_part3':
+      path               => $dcgm_telegraf_py_path,
+      after              => '        self\.m_sock = socket\(AF_INET, SOCK_DGRAM\)',
+      line               => '        self.m_sock.bind((LISTEN_HOST, LISTEN_PORT))',
+      append_on_no_match => 'false',
+      require            => Package['datacenter-gpu-manager'],
+      notify             => Service['dcgmd-telegraf.service'],
+    }
+
+    # Modification to set custom DEFAULT_TELEGRAF_PORT
+    file_line { 'dcgm_telegraf_py_set_DEFAULT_TELEGRAF_PORT':
+      path               => $dcgm_telegraf_py_path,
+      match              => '^DEFAULT_TELEGRAF_PORT = .*',
+      line               => "DEFAULT_TELEGRAF_PORT = ${dcgm_telegraf_port}",
+      append_on_no_match => 'false',
+      require            => Package['datacenter-gpu-manager'],
+      notify             => Service['dcgmd-telegraf.service'],
+    }
+
+    # Setup config hash
+    $dcgmd_telegraf_config = {
+      'exec_start'            => $exec_start,
+      'dcgm_telegraf_py_path' => $dcgm_telegraf_py_path,
+    }
+
+    # Setup dcgmd-telegraf systemd service
+    systemd::unit_file { 'dcgmd-telegraf.service':
+      content => epp( "${module_name}/dcgmd-telegraf.service.epp", $dcgmd_telegraf_config),
+      enable  => $enable,
+      active  => $enable,
+      before  => File['/etc/telegraf/telegraf.d/dcgmd.conf'],
+    }
+  
+    #
+    # Setup dcgmd telegraf config
+    #
+    $dcgm_conf = { dcgm_telegraf_port => $dcgm_telegraf_port, }
+    file { '/etc/telegraf/telegraf.d/dcgmd.conf':
+      ensure  => $ensure_parm,
+      content => epp( "${module_name}/dcgmd.conf.epp", $dcgm_conf ),
+      mode    => '0640',
+      owner   => 'root',
+      group   => 'telegraf',
+      notify  => Service['telegraf'],
+    }
   }
-
-  #
-  # Setup dcgmd-telegraf
-  #
-
-  # Setup variables
-  if find_file('/usr/bin/python3') {
-    $exec_start = '/usr/bin/python3'
-    $dcgm_telegraf_py_path = '/usr/local/dcgm/bindings/python3/dcgm_telegraf.py'
-  } elsif find_file('/usr/bin/python') {
-    $exec_start = '/usr/bin/python'
-    $dcgm_telegraf_py_path = '/usr/local/dcgm/bindings/dcgm_telegraf.py'
-  } else {
-    fail('Unable to determine python version')
-  }
-
-  # TMP fix in place for some bug in NVIDIA DCGM
-  file_line { 'fix_dcgm_telegraf_py':
-    path               => $dcgm_telegraf_py_path,
-    match              => '        self\.m_sock.sendto\(payload, self\.m_dest\)',
-    line               => '        self.m_sock.sendto(payload.encode(), self.m_dest)',
-    append_on_no_match => 'false',
-    require            => Package['datacenter-gpu-manager'],
-    notify             => Service['dcgmd-telegraf.service'],
-  }
-
-  # First Modification so dcgmd-telegraf listens on a static port and only on localhost
-  file_line { 'dcgm_telegraf_py_localhost_listen_only':
-    path               => $dcgm_telegraf_py_path,
-    after              => '^DEFAULT_TELEGRAF_PORT = .*',
-    line               => "LISTEN_HOST = '127.0.0.1'",
-    append_on_no_match => 'false',
-    require            => Package['datacenter-gpu-manager'],
-    notify             => Service['dcgmd-telegraf.service'],
-  }
-
-  # Second Modification so dcgmd-telegraf listens on a static port and only on localhost
-  file_line { 'dcgm_telegraf_py_localhost_listen_only_part2':
-    path    => $dcgm_telegraf_py_path,
-    after   => "LISTEN_HOST = '127.0.0.1'",
-    match   => '^LISTEN_PORT = .*',
-    line    => "LISTEN_PORT = ${dcgm_telegraf_py_port}",
-    require => [ Package['datacenter-gpu-manager'], File_Line['dcgm_telegraf_py_localhost_listen_only'] ],
-    notify  => Service['dcgmd-telegraf.service'],
-  }
-
-  # Third Modification so dcgmd-telegraf listens on a static port and only on localhost
-  file_line { 'dcgm_telegraf_py_localhost_listen_only_part3':
-    path               => $dcgm_telegraf_py_path,
-    after              => '        self\.m_sock = socket\(AF_INET, SOCK_DGRAM\)',
-    line               => '        self.m_sock.bind((LISTEN_HOST, LISTEN_PORT))',
-    append_on_no_match => 'false',
-    require            => Package['datacenter-gpu-manager'],
-    notify             => Service['dcgmd-telegraf.service'],
-  }
-
-  # Modification to set custom DEFAULT_TELEGRAF_PORT
-  file_line { 'dcgm_telegraf_py_set_DEFAULT_TELEGRAF_PORT':
-    path               => $dcgm_telegraf_py_path,
-    match              => '^DEFAULT_TELEGRAF_PORT = .*',
-    line               => "DEFAULT_TELEGRAF_PORT = ${dcgm_telegraf_port}",
-    append_on_no_match => 'false',
-    require            => Package['datacenter-gpu-manager'],
-    notify             => Service['dcgmd-telegraf.service'],
-  }
-
-  # Setup config hash
-  $dcgmd_telegraf_config = {
-    'exec_start'            => $exec_start,
-    'dcgm_telegraf_py_path' => $dcgm_telegraf_py_path,
-  }
-
-  # Setup dcgmd-telegraf systemd service
-  systemd::unit_file { 'dcgmd-telegraf.service':
-    content => epp( "${module_name}/dcgmd-telegraf.service.epp", $dcgmd_telegraf_config),
-    enable  => $enable,
-    active  => $enable,
-    before  => File['/etc/telegraf/telegraf.d/dcgmd.conf'],
-  }
-
-  #
-  # Setup dcgmd telegraf config
-  #
-  $dcgm_conf = { dcgm_telegraf_port => $dcgm_telegraf_port, }
-  file { '/etc/telegraf/telegraf.d/dcgmd.conf':
-    ensure  => $ensure_parm,
-    content => epp( "${module_name}/dcgmd.conf.epp", $dcgm_conf ),
-    mode    => '0640',
-    owner   => 'root',
-    group   => 'telegraf',
-    notify  => Service['telegraf'],
-  }
-
 }

--- a/manifests/dcgm/telegraf.pp
+++ b/manifests/dcgm/telegraf.pp
@@ -9,12 +9,6 @@
 # @param enable
 #   Enable or disable telegraf reporting for DCGM
 #
-# @param allownvdebugging
-#   Enable a file check to not reenable dcgm when a user is debugging
-#
-# @param nvidia_debug_check
-#   The file to check to see if user is debugging and not start the service
-#
 # @example
 #   include profile_gpu::dcgm::telegraf
 class profile_gpu::dcgm::telegraf (
@@ -30,9 +24,9 @@ class profile_gpu::dcgm::telegraf (
   }
   
  
-  # Setup nvidia-dcgm systemd service
-  #
   if $facts['nvdebugging'] != true {
+    # Setup nvidia-dcgm systemd service
+    #
     systemd::unit_file { 'nvidia-dcgm.service':
       content => file("${module_name}/nvidia-dcgm.service"),
       enable  => $enable,


### PR DESCRIPTION
In order to enable Nvidia performance counters on Ampere and older cards (Hopper may not require this work around), DCGM must not be running and collecting data. Disabling DCGM and Telegraf can be done via a Slurm prolog/epilog (an example is listed below. To make this profile not restart the services, a fact has been created to look for a file.