### PR TITLE
SVCPLAN-3512: fix path to dcgmi stats.sh in dcgmd.conf

### DIFF
--- a/files/dcgmd.conf
+++ b/files/dcgmd.conf
@@ -1,6 +1,6 @@
 # This file is managed by Puppet, manual changes will be lost
 [[inputs.exec]]
-  command = "/etc/telegraf/scripts/dcgmi_stats.sh"
+  command = "/etc/telegraf/scripts/dcgm/dcgmi_stats.sh"
   interval = "1m"
   timeout = "30s"
   data_format = "influx"


### PR DESCRIPTION
JD believes this fix is all that is necessary. 