### PR TITLE
SVCPLAN-4534: Fix issue #2 #14 #15

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -9,7 +9,7 @@ profile_gpu::dcgm::install::bind_src_path: ""          # See reference.md for wh
 profile_gpu::dcgm::install::install_dcgm: true
 profile_gpu::dcgm::install::packages:
   - "datacenter-gpu-manager"
-profile_gpu::dcgm::install::dcgm_version: "latest"
+profile_gpu::dcgm::install::dcgm_version: "installed"
 
 profile_gpu::dcgm::telegraf::enable: true
 

--- a/lib/facter/gpu_nvidia.rb
+++ b/lib/facter/gpu_nvidia.rb
@@ -1,0 +1,5 @@
+Facter.add(:gpu_nvidia) do
+  setcode do
+    `lspci | grep -i nvidia | egrep -iqw '3D|Tesla' && echo true || echo false`.strip
+  end
+end

--- a/manifests/dcgm/telegraf.pp
+++ b/manifests/dcgm/telegraf.pp
@@ -8,7 +8,16 @@
 class profile_gpu::dcgm::telegraf (
   Boolean $enable,
 ) {
-  if ($enable) {
+  if ($enable and $facts['gpu_nvidia'] ) {
+    if $facts['nvdebugging'] != true {
+      # Setup nvidia-dcgm systemd service
+      systemd::unit_file { 'nvidia-dcgm.service':
+        content => file("${module_name}/nvidia-dcgm.service"),
+        enable  => $enable,
+        require => Package['datacenter-gpu-manager'],
+        active  => $enable,
+      }
+    }
     $ensure_parm = 'present'
   } else {
     $ensure_parm = 'absent'
@@ -37,16 +46,5 @@ class profile_gpu::dcgm::telegraf (
     owner   => 'root',
     group   => 'telegraf',
     notify  => Service['telegraf'],
-  }
-
-  if $facts['nvdebugging'] != true {
-    # Setup nvidia-dcgm systemd service
-    #
-    systemd::unit_file { 'nvidia-dcgm.service':
-      content => file("${module_name}/nvidia-dcgm.service"),
-      enable  => $enable,
-      require => Package['datacenter-gpu-manager'],
-      active  => $enable,
-    }
   }
 }


### PR DESCRIPTION
- Fix #2 - Create custom fact `gpu_nvidia` which is true/false
- Fix #14 - Default hiera `dcgm_version: "installed"`
- Fix #15 - Fix `profile_gpu::dcgm::telegraf` to use custom fact `gpu_nvidia` and only configure if true & enabled

This has been tested on `mg094`.