### PR TITLE
SVCPLAN-4534: Only do dcgm classes if gpu_nvidia installed

### DIFF
--- a/lib/facter/debugging_check.rb
+++ b/lib/facter/debugging_check.rb
@@ -1,9 +1,0 @@
-Facter.add('nvdebugging') do
-  setcode do
-    if File.exist? '/var/spool/slurmd/nvperfenabled'
-      true
-    else
-      false
-    end
-  end
-end

--- a/lib/facter/gpu_nvidia.rb
+++ b/lib/facter/gpu_nvidia.rb
@@ -1,5 +1,0 @@
-Facter.add(:gpu_nvidia) do
-  setcode do
-    `lspci | grep -i nvidia | egrep -iqw '3D|Tesla' && echo true || echo false`.strip
-  end
-end

--- a/lib/facter/has_gpu_nvidia.rb
+++ b/lib/facter/has_gpu_nvidia.rb
@@ -1,0 +1,6 @@
+Facter.add('has_gpu_nvidia') do
+  setcode do
+    Facter::Core::Execution.execute('lspci | grep -i nvidia | egrep -iqw "3D|Tesla"')
+    $CHILD_STATUS.success?
+  end
+end

--- a/lib/facter/has_slurm_nvperf_enabled.rb
+++ b/lib/facter/has_slurm_nvperf_enabled.rb
@@ -1,0 +1,6 @@
+Facter.add('has_slurm_nvperf_enabled') do
+  setcode do
+    Facter::Core::Execution.execute('test -f /var/spool/slurmd/nvperfenabled')
+    $CHILD_STATUS.success?
+  end
+end

--- a/manifests/dcgm/install.pp
+++ b/manifests/dcgm/install.pp
@@ -71,7 +71,7 @@ class profile_gpu::dcgm::install (
   Array[String] $packages,
   String        $dcgm_version,
 ) {
-  if ($install_dcgm) {
+  if ( $install_dcgm and $facts['has_gpu_nvidia'] ) {
     if ($bind_mount_install) {
       # We need to setup bind mounts for DCGM to install into
 

--- a/manifests/dcgm/telegraf.pp
+++ b/manifests/dcgm/telegraf.pp
@@ -8,8 +8,8 @@
 class profile_gpu::dcgm::telegraf (
   Boolean $enable,
 ) {
-  if ($enable and $facts['gpu_nvidia'] ) {
-    if $facts['nvdebugging'] != true {
+  if ( $enable and $facts['has_gpu_nvidia'] ) {
+    if ! $facts['has_slurm_nvperf_enabled'] {
       # Setup nvidia-dcgm systemd service
       systemd::unit_file { 'nvidia-dcgm.service':
         content => file("${module_name}/nvidia-dcgm.service"),


### PR DESCRIPTION
Pull request #17 was incomplete. The way we were comparing the custom fact was incorrect -- we need to check the value of the fact, not just check that it exists.

This change has manually been tested on:
- `mforgegpu3`
- `mforgegpu5`
- `mforgegpu7`
- `mforgehn4`
- `mforgehn5`
- `mforgehn9`