### PR TITLE
SVCPLAN-8288: BREAKING - support alternate package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,39 @@ set these hiera variables (we have a TODO to make this use a custom fact):
 - `profile_gpu::dcgm::install::install_dcgm: false`
 - `profile_gpu::dcgm::telegraf::enable: false`
 
-To collect telegraf metrics you must define the hiera value `profile_gpu::dcgm::install::bind_mount_install`.
+To collect telegraf metrics for NVIDIA GPUs you should set the hiera value `profile_gpu::dcgm::install::bind_mount_install`.
 
 - This is set to no value in data/common.yaml and must be defined in your project control-repo.
-- See REFERENCE.md for details
+- The reason for this parameter is that DCGM v3 installs files in /usr/local/, which may be located in a shared filesystem on some NCSA clusters.
+- DCGM v4 does NOT install anything into /usr/local/, and setting this to 'false' when installing v4 is generally going to be OK.
+- See [REFERENCE.md](REFERENCE.md) for details
+
+Telegraf metrics for NVIDIA GPUs depend on the installation of DCGM. This module now defaults to installing DCGM v4 with compatibility for CUDA 12.
+
+If you would like to install compatibility for a different major version of CUDA, or additional major versions of CUDA, make sure the relevant `-cuda**` package(s) available and set data like the following in your control repo, including the relevant `cuda**` package for each version of CUDA you would like to support, e.g.:
+```yaml
+profile_gpu::dcgm::install::packages:
+  - "datacenter-gpu-manager-4-cuda12"
+  - "datacenter-gpu-manager-4-cuda13"
+  - "datacenter-gpu-manager-4-proprietary"
+```
+It is not necessary to install the corresponding `datacenter-gpu-manager-4-proprietary-cuda**` package(s), and they are rather large. If it is pulled down as a "weak dependency" you may want to uninstall it (or prevent it from being installed in the first place).
+
+If you would like to install v3, set the following in your control repo:
+```yaml
+profile_gpu::dcgm::install::packages:
+  - "datacenter-gpu-manager"
+```
+
+This profile is not designed to upgrade a v3 installation to v4. To do that you should update your control repo, as necessary, and:
+```bash
+systemctl stop puppet telegraf nvidia-dcgm
+yum -y remove 'datacenter-gpu-manager*'
+# optionally remove the local bindmount for v3
+puppet agent -t
+```
+
+Before adding/removing `-cuda**` support packages you may want to perform a similar operation (or at least stop services).
 
 In order to enable Nvidia performance counters on Ampere and older cards (Hopper may not require this work around), DCGM must not be running and collecting data. Disabling DCGM and Telegraf can be done via a Slurm prolog/epilog (an example is listed below. To make this profile not restart the services, a fact has been created to look for a file. This file is hardcoded to look at '/var/spool/slurmd/nvperfenabled'. If this file is found, DCGM and Telegraf will not be restarted.
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -7,9 +7,10 @@ profile_gpu::dcgm::install::bind_parent_dst_mount: ""  # See reference.md for wh
 profile_gpu::dcgm::install::bind_src_path: ""          # See reference.md for when this is needed
 
 profile_gpu::dcgm::install::install_dcgm: true
-profile_gpu::dcgm::install::packages:
-  - "datacenter-gpu-manager"
 profile_gpu::dcgm::install::dcgm_version: "installed"
+profile_gpu::dcgm::install::packages:
+  - "datacenter-gpu-manager-4-cuda12"
+  - "datacenter-gpu-manager-4-proprietary"
 
 profile_gpu::dcgm::telegraf::enable: true
 

--- a/manifests/dcgm/telegraf.pp
+++ b/manifests/dcgm/telegraf.pp
@@ -14,7 +14,9 @@ class profile_gpu::dcgm::telegraf (
       systemd::unit_file { 'nvidia-dcgm.service':
         content => file("${module_name}/nvidia-dcgm.service"),
         enable  => $enable,
-        require => Package['datacenter-gpu-manager'],
+        require => [
+          Package[$profile_gpu::dcgm::install::packages],
+        ],
         active  => $enable,
       }
     }


### PR DESCRIPTION
BREAKING: This update changes the default version of DCGM from v3 to v4 (with CUDA 12 support). Please see README.md for instructions for upgrading from v3 and/or need to support different/additional versions of CUDA.

This update adjusts a Puppet 'require' dependency to use use the DCGM package variable instead of hard-coding the name, to support customizing which packages are installed while still enforcing the dependency.